### PR TITLE
Fix Export Full to properly render eraser strokes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,7 +47,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             # Main branch → dev, 0.0.0-dev
             type=raw,value=dev,enable={{is_default_branch}}
             type=raw,value=0.0.0-dev,enable={{is_default_branch}}
@@ -55,8 +55,8 @@ jobs:
             type=ref,event=branch,enable=${{ startsWith(github.ref, 'refs/heads/experimental/') }},prefix=0.0.0-experimental-,suffix=
             # Pull requests → pr-<number>
             type=ref,event=pr,prefix=pr-
-            # SHA tag for branch builds only (not tags)
-            type=sha,enable=${{ github.ref_type == 'branch' }},prefix={{branch}}-,format=short
+            # SHA tag for branch builds only (not tags or PRs)
+            type=sha,enable=${{ github.ref_type == 'branch' && github.event_name != 'pull_request' }},prefix={{branch}}-,format=short
 
       - name: Determine version
         id: version

--- a/app/client/creator.js
+++ b/app/client/creator.js
@@ -484,14 +484,13 @@ document.getElementById('exportFullBtn').addEventListener('click', () => {
 
     exportCtx.lineCap = 'round';
     exportCtx.lineJoin = 'round';
+    exportCtx.globalCompositeOperation = 'source-over';
 
-    // Handle eraser strokes
+    // Handle eraser strokes - draw white to match background
     if (stroke.tool === 'eraser') {
-      exportCtx.globalCompositeOperation = 'destination-out';
-      exportCtx.strokeStyle = 'rgba(0,0,0,1)'; // Opaque black for erasing
+      exportCtx.strokeStyle = '#ffffff';
       exportCtx.lineWidth = 20;
     } else {
-      exportCtx.globalCompositeOperation = 'source-over';
       exportCtx.strokeStyle = stroke.color || '#000000';
       exportCtx.lineWidth = stroke.width || 3;
     }

--- a/app/client/creator.js
+++ b/app/client/creator.js
@@ -487,6 +487,14 @@ document.getElementById('exportFullBtn').addEventListener('click', () => {
     exportCtx.lineCap = 'round';
     exportCtx.lineJoin = 'round';
 
+    // Handle eraser strokes
+    if (stroke.tool === 'eraser') {
+      exportCtx.globalCompositeOperation = 'destination-out';
+      exportCtx.lineWidth = 20;
+    } else {
+      exportCtx.globalCompositeOperation = 'source-over';
+    }
+
     exportCtx.beginPath();
     const startX = stroke.points[0].x - minX;
     const startY = stroke.points[0].y - minY;

--- a/app/client/creator.js
+++ b/app/client/creator.js
@@ -482,17 +482,18 @@ document.getElementById('exportFullBtn').addEventListener('click', () => {
   strokes.forEach(stroke => {
     if (!stroke || !stroke.points || stroke.points.length < 2) return;
 
-    exportCtx.strokeStyle = stroke.color || '#000000';
-    exportCtx.lineWidth = stroke.width || 3;
     exportCtx.lineCap = 'round';
     exportCtx.lineJoin = 'round';
 
     // Handle eraser strokes
     if (stroke.tool === 'eraser') {
       exportCtx.globalCompositeOperation = 'destination-out';
+      exportCtx.strokeStyle = 'rgba(0,0,0,1)'; // Opaque black for erasing
       exportCtx.lineWidth = 20;
     } else {
       exportCtx.globalCompositeOperation = 'source-over';
+      exportCtx.strokeStyle = stroke.color || '#000000';
+      exportCtx.lineWidth = stroke.width || 3;
     }
 
     exportCtx.beginPath();

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zorlack/syncpit",
-  "version": "0.5.1",
+  "version": "0.9.2-dev1-2-g1b0ec18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zorlack/syncpit",
-      "version": "0.5.1",
+      "version": "0.9.2-dev1-2-g1b0ec18",
       "dependencies": {
         "express": "^4.18.2",
         "html5-qrcode": "^2.3.8",

--- a/app/package.json
+++ b/app/package.json
@@ -42,7 +42,6 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "canvas": "^3.2.0",
     "express": "^4.18.2",
     "html5-qrcode": "^2.3.8",
     "qrcode": "^1.5.4",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zorlack/syncpit",
-  "version": "0.9.2-dev1-1-g49dce4f",
+  "version": "0.9.2-dev1-2-g1b0ec18",
   "description": "Ephemeral real-time collaborative whiteboard - no accounts, no bullshit",
   "main": "welld.js",
   "bin": {
@@ -42,6 +42,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
+    "canvas": "^3.2.0",
     "express": "^4.18.2",
     "html5-qrcode": "^2.3.8",
     "qrcode": "^1.5.4",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zorlack/syncpit",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Ephemeral real-time collaborative whiteboard - no accounts, no bullshit",
   "main": "welld.js",
   "bin": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zorlack/syncpit",
-  "version": "0.9.1",
+  "version": "0.9.2-dev1-1-g49dce4f",
   "description": "Ephemeral real-time collaborative whiteboard - no accounts, no bullshit",
   "main": "welld.js",
   "bin": {


### PR DESCRIPTION
Fixes #9

## Problem
The Export Full function was not checking for eraser tool strokes, causing them to be rendered as regular pen strokes instead of erasing content in the exported image.

## Solution
Added check for `stroke.tool === 'eraser'` in the export rendering loop and set `globalCompositeOperation` to `'destination-out'` to properly erase pixels in the exported image, matching the on-canvas behavior.

## Changes
- Added eraser tool detection in Export Full handler
- Set proper composite operation for eraser strokes
- Eraser strokes now correctly erase content in exported images

## Testing
- Draw some content
- Use eraser to remove parts of it
- Export Full
- Verify erased areas are transparent/removed in exported PNG